### PR TITLE
[pouchdb-core] duplicate Blob interface inline

### DIFF
--- a/types/pouchdb-core/index.d.ts
+++ b/types/pouchdb-core/index.d.ts
@@ -8,7 +8,8 @@
 
 /// <reference types="debug" />
 /// <reference types="pouchdb-find" />
-/// <reference types="dom" />
+
+interface Blob {}
 
 interface Buffer extends Uint8Array {
     write(string: string, offset?: number, length?: number, encoding?: string): number;

--- a/types/pouchdb-core/index.d.ts
+++ b/types/pouchdb-core/index.d.ts
@@ -9,7 +9,11 @@
 /// <reference types="debug" />
 /// <reference types="pouchdb-find" />
 
-interface Blob {}
+interface Blob {
+    readonly size: number;
+    readonly type: string;
+    slice(start?: number, end?: number, contentType?: string): Blob;
+}
 
 interface Buffer extends Uint8Array {
     write(string: string, offset?: number, length?: number, encoding?: string): number;


### PR DESCRIPTION
Forward declare `Blob` instead of using a triple-slash directive.
`/// <reference types="dom">` looks for 'dom' in Definitely Typed, but the 'dom' lib is built into TypeScript.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
 - [`/// <reference types="dom" />`](https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html#-reference-types-) looks in Definitely Typed, but 'dom' is packaged with TypeScript.
 - [`/// <reference lib="dom" />`](https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html#-reference-lib-) would require TypeScript 3.0, which fails [`dtslint`'s TypeScript version check](https://github.com/Microsoft/definitelytyped-header-parser/blob/fef4df579aec54772cc5e0bbac071cff21e57a4c/index.ts#L261)
